### PR TITLE
Update services.js

### DIFF
--- a/ernest/static/js/services.js
+++ b/ernest/static/js/services.js
@@ -8,9 +8,13 @@ ernest.value('version', '0.1a1');
 ernest.factory('GitHubRepoApi', ['$resource',
     function($resource) {
         function augmentPR(pr) {
-            var bugNums = (pr.title || '').match(/\bbug \d+\b/gi) || [];
-            bugNums = bugNums.map(function (num) {
-                return num.replace(/bug /i, '');
+            var bugNums = [];
+            // Not actually replacing. This is just the best way to iterate over every match of a regex.
+            // This grabs bug stanzas (defined as a pair of brackets that start with "bug", and some
+            // numbers and maybe commas and spaces). Then it breaks them up into their component numbers.
+            str.replace(/\[bug\s*\d+(?:,\s*\d+)*\]/gi, function(stanza) {
+                // We have a bug stanza
+                bugNums = bugNums.concat(stanza.split(/[^\d]/).filter(function(bn) { return bn != ""; }));
             });
 
             return {


### PR DESCRIPTION
This allows for both "[Bug 123][Bug 345] Foo" and "[Bug 123, 456] Foo" style commits. It also allows for mixing and matching, flexible use of spaces, and case insensitivity. But the brackets are required now, which is a change from what it was before.

Caveat: I tested this function in isolation in a scratchpad. I didn't actually test Ernest with it.

r?